### PR TITLE
Add exit from dream room

### DIFF
--- a/public/field.html
+++ b/public/field.html
@@ -21,6 +21,7 @@
       <div id="npc">
         <p><strong>Knitting Girl:</strong> <span id="npcQuote">Welcome to the dream...</span></p>
       </div>
+      <button id="exitDreamButton">Return to Waiting Room</button>
     </aside>
     <main id="chatArea">
       <div id="messages" class="messages"></div>

--- a/public/script.js
+++ b/public/script.js
@@ -190,8 +190,14 @@ socket.on('nameUpdated', ({ id, name }) => {
 socket.on('roomChanged', ({ id, room, player }) => {
   if (players[id]) {
     players[id] = player;
-    // If this is us and we moved to the dream, redirect handled in 'enteredDream'
-    if (id !== myId) {
+    if (id === myId) {
+      myPlayer = player;
+      if (room === 'OpenField' && !isField()) {
+        window.location.href = 'field.html';
+      } else if (room === 'WaitingRoom' && !isLobby()) {
+        window.location.href = 'index.html';
+      }
+    } else {
       updatePlayerList();
       drawPlayers();
     }
@@ -269,6 +275,14 @@ const enterDreamBtn = document.getElementById('enterDreamButton');
 if (enterDreamBtn) {
   enterDreamBtn.addEventListener('click', () => {
     socket.emit('enterDream');
+  });
+}
+
+// Exit Dream button
+const exitDreamBtn = document.getElementById('exitDreamButton');
+if (exitDreamBtn) {
+  exitDreamBtn.addEventListener('click', () => {
+    socket.emit('changeRoom', 'WaitingRoom');
   });
 }
 


### PR DESCRIPTION
## Summary
- add `Return to Waiting Room` button in the dream field
- support leaving the dream on the client side

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_688790b208c88327a7b4d7ea688e2373