### PR TITLE
Implement basic customization and chat bubbles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Knitting 3D</title>
+  <title>Waiting Room</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -11,6 +11,8 @@
     <div id="modalBox">
       <h2>Enter your name</h2>
       <input id="nameInput" placeholder="Your name" maxlength="16" />
+      <label for="colorInput">Color:</label>
+      <input type="color" id="colorInput" />
       <button id="startGame">Start</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow players to choose their color and save name/color locally with 30-day reuse
- display chat bubbles above players that fade out
- update lobby title to "Waiting Room"

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68933f116d788327bcee2228c3664eda