### PR TITLE
feat: add background audio, chat history, and friends system

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ app.use("/models", express.static("public/models"));
 
 // player store: id -> { x,y,z, name, color, isGuest, google: {sub,name,picture} }
 const players = {};
+const friends = {}; // id -> Set of friend ids
 
 io.on("connection", (socket) => {
 
@@ -56,8 +57,41 @@ io.on("connection", (socket) => {
     io.emit("chat", { id: socket.id, text: String(txt||"").slice(0,160) });
   });
 
+  socket.on("typing", (flag) => {
+    socket.broadcast.emit("typing", { id: socket.id, typing: !!flag });
+  });
+
+  socket.on("friendRequest", ({ to }) => {
+    const me = players[socket.id];
+    const target = players[to];
+    if (!me || me.isGuest || !target || target.isGuest) return;
+    io.to(to).emit("friendRequest", { from: socket.id, name: me.name });
+  });
+
+  socket.on("friendAccept", ({ from }) => {
+    const me = players[socket.id];
+    const other = players[from];
+    if (!me || me.isGuest || !other || other.isGuest) return;
+    friends[socket.id] = friends[socket.id] || new Set();
+    friends[from] = friends[from] || new Set();
+    friends[socket.id].add(from);
+    friends[from].add(socket.id);
+    io.to(socket.id).emit("friendAccepted", { id: from, name: other?.name });
+    io.to(from).emit("friendAccepted", { id: socket.id, name: me?.name });
+  });
+
+  socket.on("privateChat", ({ to, text }) => {
+    if (friends[socket.id]?.has(to)) {
+      const msg = String(text||"").slice(0,160);
+      io.to(to).emit("privateChat", { id: socket.id, text: msg });
+      socket.emit("privateChat", { id: socket.id, text: msg });
+    }
+  });
+
   socket.on("disconnect", () => {
     delete players[socket.id];
+    delete friends[socket.id];
+    Object.values(friends).forEach((set) => set.delete(socket.id));
     io.emit("removePlayer", socket.id);
   });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -113,6 +113,21 @@ button.guest{background:#10b981;border:0;color:#fff;font-weight:600;
   padding:10px 12px;border-radius:10px;outline:none}
 #chatSend{background:#334155;color:#e2e8f0;border:0;border-radius:10px;
   padding:10px 14px;font-weight:600;cursor:pointer}
+
+/* top-right utility buttons */
+.topBtn{position:fixed;top:12px;right:12px;background:#334155;color:#e2e8f0;
+  border:0;border-radius:8px;padding:8px 12px;cursor:pointer;z-index:11}
+#friendsBtn{right:92px}
+
+/* side panels */
+.sidePanel{position:fixed;top:0;right:0;width:260px;height:100%;
+  background:rgba(9,13,24,.95);border-left:1px solid #1f2a44;padding:12px;
+  overflow-y:auto;overflow-x:hidden;transform:translateX(100%);transition:transform .25s;
+  z-index:10;color:#e2e8f0}
+.sidePanel.open{transform:translateX(0)}
+#friendsPanel div{padding:6px;border-bottom:1px solid #1f2a44;cursor:pointer}
+#friendsPanel div:hover{background:#1f2a44}
+#historyPanel div{padding:6px;border-bottom:1px solid #1f2a44;word-break:break-word;overflow-wrap:anywhere;}
 </style>
 
 <!-- Google Identity Services -->
@@ -159,6 +174,14 @@ button.guest{background:#10b981;border:0;color:#fff;font-weight:600;
   <input id="chatInput" type="text" placeholder="Type a message…" maxlength="160" autocomplete="off">
   <button id="chatSend">Send</button>
 </div>
+
+<!-- top buttons -->
+<button id="historyBtn" class="topBtn">History</button>
+<button id="friendsBtn" class="topBtn">Friends</button>
+
+<!-- side panels -->
+<div id="historyPanel" class="sidePanel"></div>
+<div id="friendsPanel" class="sidePanel"><h4>Friends</h4><div id="friendsList"></div></div>
 
 <!-- ======== dust motes generator ======== -->
 <script>

--- a/public/main.js
+++ b/public/main.js
@@ -27,6 +27,13 @@ const previewWrap = document.getElementById('previewWrap');
 const chatBar   = document.getElementById('chatBar');
 const chatInput = document.getElementById('chatInput');
 const chatSend  = document.getElementById('chatSend');
+const historyBtn   = document.getElementById('historyBtn');
+const friendsBtn   = document.getElementById('friendsBtn');
+const historyPanel = document.getElementById('historyPanel');
+const friendsPanel = document.getElementById('friendsPanel');
+const friendsList  = document.getElementById('friendsList');
+friendsBtn.style.display = 'none';
+friendsPanel.style.display = 'none';
 
 const socket = window.io();
 
@@ -103,6 +110,17 @@ const loader = new FBXLoader();
 const players = new Map(); // id -> Group
 let myId = null;
 let targetPos = null;
+let chatTarget = null; // current private chat target
+const chatHistory = [];
+const friends = new Map();
+let isGoogleUser = false;
+
+const bgAudio = new Audio('https://cdn.pixabay.com/download/audio/2023/03/26/audio_b1bff9e603.mp3?filename=ambient-14538.mp3');
+bgAudio.loop = true;
+bgAudio.volume = 0.4;
+
+let typing = false;
+let typingTimer = null;
 
 const raycaster = new THREE.Raycaster();
 const mouse = new THREE.Vector2();
@@ -110,6 +128,7 @@ const cameraOffset = new THREE.Vector3(0, 6, 10);
 
 // -- Chat bubble state ----------------------------------------------------
 const activeBubbles = [];
+const BUBBLE_GAP = 0.5;
 
 // -- Materials / tint helpers --------------------------------------------
 function tintMaterial(m, color) {
@@ -192,7 +211,7 @@ function makeNameTag(text) {
 // Chat bubbles ------------------------------------------------------------
 function makeChatBubble(text) {
   const ctx = document.createElement('canvas').getContext('2d');
-  const maxWidth = 260;
+  const maxWidth = 360;
   ctx.font = '600 28px system-ui, sans-serif';
 
   // -- Simple word-wrap ---------------------------------------------------
@@ -256,7 +275,6 @@ function makeChatBubble(text) {
   });
   const sprite = new THREE.Sprite(mat);
   sprite.scale.set(w / 110, h / 110, 1);
-  sprite.position.set(0, 2.6, 0); // above name tag
 
   return sprite;
 }
@@ -265,13 +283,60 @@ function showChatBubble(id, text) {
   const root = players.get(id);
   if (!root) return;
 
-  if (root.userData.chatBubble) root.remove(root.userData.chatBubble);
-
+  const list = root.userData.chatBubbles || [];
   const bubble = makeChatBubble(text);
+  bubble.position.set(0, 2.6 + list.length * BUBBLE_GAP, 0);
   root.add(bubble);
-  root.userData.chatBubble = bubble;
+  list.push(bubble);
+  root.userData.chatBubbles = list;
 
-  activeBubbles.push({ sprite: bubble, root, ttl: 4.5 }); // seconds
+  if (list.length > 3) {
+    const old = list.shift();
+    if (old) {
+      root.remove(old);
+      const idx = activeBubbles.findIndex((b) => b.sprite === old);
+      if (idx >= 0) activeBubbles.splice(idx, 1);
+    }
+    list.forEach((b, i) => b.position.set(0, 2.6 + i * BUBBLE_GAP, 0));
+  }
+
+  if (root.userData.typingBubble) {
+    root.userData.typingBubble.position.y = 2.6 + list.length * BUBBLE_GAP;
+  }
+
+  activeBubbles.push({ sprite: bubble, root, ttl: 4.5 });
+}
+
+function showTyping(id, flag) {
+  const root = players.get(id);
+  if (!root) return;
+  if (flag) {
+    if (root.userData.typingBubble) return;
+    const bubble = makeChatBubble('...');
+    bubble.scale.multiplyScalar(0.6);
+    bubble.position.set(
+      0,
+      2.6 + (root.userData.chatBubbles ? root.userData.chatBubbles.length * BUBBLE_GAP : 0),
+      0
+    );
+    root.add(bubble);
+    root.userData.typingBubble = bubble;
+  } else {
+    const b = root.userData.typingBubble;
+    if (b) {
+      root.remove(b);
+      delete root.userData.typingBubble;
+    }
+  }
+}
+
+function addHistory(id, text, isPrivate = false) {
+  const name = players.get(id)?.userData?.name || 'Player';
+  const row = document.createElement('div');
+  row.textContent = `${isPrivate ? '(PM) ' : ''}${name}: ${text}`;
+  historyPanel.appendChild(row);
+  historyPanel.scrollTop = historyPanel.scrollHeight;
+  chatHistory.push({ id, text, isPrivate });
 }
 
 // ------------------------------------------------------------------------
@@ -280,6 +345,9 @@ function spawnPlayer(id, pos, name, color, isLocal = false) {
   const root = new THREE.Group();
   root.position.set(pos.x, pos.y, pos.z);
   scene.add(root);
+  root.userData.id = id;
+  root.userData.name = name;
+  root.userData.isGuest = pos.isGuest;
   players.set(id, root);
 
   // Model
@@ -300,6 +368,7 @@ function spawnPlayer(id, pos, name, color, isLocal = false) {
         if (c.isMesh) {
           c.castShadow = true;
           c.receiveShadow = true;
+          c.userData.playerId = id;
         }
       });
 
@@ -313,6 +382,7 @@ function spawnPlayer(id, pos, name, color, isLocal = false) {
       const m = new THREE.MeshStandardMaterial({ color: color || '#4ADE80' });
       const mesh = new THREE.Mesh(g, m);
       mesh.castShadow = true;
+      mesh.userData.playerId = id;
       root.add(mesh);
     }
   );
@@ -333,6 +403,18 @@ function spawnPlayer(id, pos, name, color, isLocal = false) {
       mouse.x = (e.clientX / innerWidth) * 2 - 1;
       mouse.y = -(e.clientY / innerHeight) * 2 + 1;
       raycaster.setFromCamera(mouse, camera);
+
+      const objs = Array.from(players.values());
+      const phit = raycaster.intersectObjects(objs, true);
+      if (phit.length) {
+        let o = phit[0].object;
+        while (o && !o.userData.playerId) o = o.parent;
+        if (o && o.userData.playerId && o.userData.playerId !== myId) {
+          sendFriendRequest(o.userData.playerId);
+          return;
+        }
+      }
+
       const hit = raycaster.intersectObjects([floor], false);
 
       if (hit.length) {
@@ -584,8 +666,16 @@ function sendChat() {
   const text = (chatInput.value || '').trim();
   if (!text) return;
 
-  socket.emit('chat', text);
+  if (chatTarget) {
+    socket.emit('privateChat', { to: chatTarget, text });
+  } else {
+    socket.emit('chat', text);
+  }
   chatInput.value = '';
+  if (typing) {
+    typing = false;
+    socket.emit('typing', false);
+  }
 }
 chatSend.addEventListener('click', sendChat);
 chatInput.addEventListener('keydown', (e) => {
@@ -594,6 +684,70 @@ chatInput.addEventListener('keydown', (e) => {
     sendChat();
   }
 });
+
+chatInput.addEventListener('input', () => {
+  if (!typing) {
+    typing = true;
+    socket.emit('typing', true);
+  }
+  clearTimeout(typingTimer);
+  typingTimer = setTimeout(() => {
+    if (typing) {
+      typing = false;
+      socket.emit('typing', false);
+    }
+  }, 1000);
+});
+chatInput.addEventListener('blur', () => {
+  if (typing) {
+    typing = false;
+    socket.emit('typing', false);
+  }
+});
+
+historyBtn.onclick = () => historyPanel.classList.toggle('open');
+friendsBtn.onclick = () => friendsPanel.classList.toggle('open');
+
+function refreshFriendsList() {
+  friendsList.innerHTML = '';
+  const global = document.createElement('div');
+  global.textContent = 'Global Chat';
+  global.onclick = () => {
+    chatTarget = null;
+    chatInput.placeholder = 'Type a message…';
+    friendsPanel.classList.remove('open');
+  };
+  friendsList.appendChild(global);
+  friends.forEach((name, id) => {
+    const div = document.createElement('div');
+    div.textContent = name;
+    div.onclick = () => {
+      chatTarget = id;
+      chatInput.placeholder = `Message ${name}`;
+      friendsPanel.classList.remove('open');
+    };
+    friendsList.appendChild(div);
+  });
+}
+
+function sendFriendRequest(id) {
+  if (!isGoogleUser) {
+    alert('Google login required to add friends.');
+    return;
+  }
+  const info = players.get(id);
+  if (info?.userData?.isGuest) {
+    alert('Guests cannot be added as friends.');
+    return;
+  }
+  if (friends.has(id)) return;
+  const name = info?.userData?.name || 'Player';
+  if (confirm(`Add ${name} as friend?`)) {
+    socket.emit('friendRequest', { to: id });
+  }
+}
+
+refreshFriendsList();
 
 // ------------------------------------------------------------------------
 // Socket.io ----------------------------------------------------------------
@@ -617,6 +771,9 @@ function showCharCreator(idToken = null) {
   overlay.classList.remove('hidden');
   initPreview();
   updatePreviewColor(palette[selectedIdx]);
+  isGoogleUser = !!idToken;
+  friendsBtn.style.display = isGoogleUser ? 'block' : 'none';
+  friendsPanel.style.display = isGoogleUser ? 'block' : 'none';
 
   // -- Logged-in banner ---------------------------------------------------
   if (idToken) {
@@ -637,6 +794,7 @@ function showCharCreator(idToken = null) {
     overlay.classList.add('hidden');
     disposePreview();
     chatBar.classList.remove('hidden');
+    bgAudio.play().catch(() => {});
     setTimeout(() => chatInput.focus(), 50);
 
     if (idToken) {
@@ -694,7 +852,24 @@ socket.on('removePlayer', (id) => {
 });
 
 // NEW: receive chat messages -> show bubbles
-socket.on('chat', ({ id, text }) => showChatBubble(id, text));
+socket.on('chat', ({ id, text }) => {
+  showChatBubble(id, text);
+  addHistory(id, text);
+});
+socket.on('privateChat', ({ id, text }) => {
+  showChatBubble(id, text);
+  addHistory(id, text, true);
+});
+socket.on('typing', ({ id, typing }) => showTyping(id, typing));
+socket.on('friendRequest', ({ from, name }) => {
+  if (confirm(`${name} wants to be your friend. Accept?`)) {
+    socket.emit('friendAccept', { from });
+  }
+});
+socket.on('friendAccepted', ({ id, name }) => {
+  friends.set(id, name);
+  refreshFriendsList();
+});
 
 // ------------------------------------------------------------------------
 // Main loop ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- restrict friend system to Google-authenticated players and hide friend UI for guests
- widen chat bubbles and add spacing to prevent overlap
- ensure chat history wraps long messages within the panel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node index.js`


------
https://chatgpt.com/codex/tasks/task_e_689c44aed5d0832797eba78d14ad6b0a