### PR TITLE
Improve guest flow and chat UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -114,10 +114,9 @@ button.guest{background:#10b981;border:0;color:#fff;font-weight:600;
 #chatSend{background:#334155;color:#e2e8f0;border:0;border-radius:10px;
   padding:10px 14px;font-weight:600;cursor:pointer}
 
-/* top-right utility buttons */
-.topBtn{position:fixed;top:12px;right:12px;background:#334155;color:#e2e8f0;
-  border:0;border-radius:8px;padding:8px 12px;cursor:pointer;z-index:11}
-#friendsBtn{right:92px}
+/* bottom utility bar */
+#bottomBar{position:fixed;right:12px;bottom:12px;display:flex;gap:8px;z-index:11}
+#bottomBar button{background:#334155;color:#e2e8f0;border:0;border-radius:8px;padding:8px 12px;cursor:pointer}
 
 /* side panels */
 .sidePanel{position:fixed;top:0;right:0;width:260px;height:100%;
@@ -127,6 +126,7 @@ button.guest{background:#10b981;border:0;color:#fff;font-weight:600;
 .sidePanel.open{transform:translateX(0)}
 #friendsPanel div{padding:6px;border-bottom:1px solid #1f2a44;cursor:pointer}
 #friendsPanel div:hover{background:#1f2a44}
+#historyPanel div{padding:6px;border-bottom:1px solid #1f2a44;word-break:break-word}
 </style>
 
 <!-- Google Identity Services -->
@@ -174,9 +174,11 @@ button.guest{background:#10b981;border:0;color:#fff;font-weight:600;
   <button id="chatSend">Send</button>
 </div>
 
-<!-- top buttons -->
-<button id="historyBtn" class="topBtn">History</button>
-<button id="friendsBtn" class="topBtn">Friends</button>
+<!-- bottom utility bar -->
+<div id="bottomBar">
+  <button id="historyBtn">History</button>
+  <button id="friendsBtn">Friends</button>
+</div>
 
 <!-- side panels -->
 <div id="historyPanel" class="sidePanel"></div>

--- a/public/login.js
+++ b/public/login.js
@@ -4,7 +4,11 @@ export function initLoginGate({ onGuest, onGoogle }) {
   const guestBtn  = document.getElementById('guestBtn');
   const loginMsg  = document.getElementById('loginMsg');
 
-  guestBtn.onclick = onGuest;
+  guestBtn.onclick = () => {
+    // Hide the welcome gate when playing as guest
+    loginGate.style.display = 'none';
+    onGuest();
+  };
 
   /* global google */
   google.accounts.id.initialize({

--- a/public/main.js
+++ b/public/main.js
@@ -207,7 +207,7 @@ function makeNameTag(text) {
 // Chat bubbles ------------------------------------------------------------
 function makeChatBubble(text) {
   const ctx = document.createElement('canvas').getContext('2d');
-  const maxWidth = 260;
+  const maxWidth = 360;
   ctx.font = '600 28px system-ui, sans-serif';
 
   // -- Simple word-wrap ---------------------------------------------------
@@ -275,13 +275,16 @@ function makeChatBubble(text) {
   return sprite;
 }
 
+const BUBBLE_BASE = 2.8;
+const BUBBLE_SPACING = 0.5;
+
 function showChatBubble(id, text) {
   const root = players.get(id);
   if (!root) return;
 
   const list = root.userData.chatBubbles || [];
   const bubble = makeChatBubble(text);
-  bubble.position.set(0, 2.6 + list.length * 0.35, 0);
+  bubble.position.set(0, BUBBLE_BASE + list.length * BUBBLE_SPACING, 0);
   root.add(bubble);
   list.push(bubble);
   root.userData.chatBubbles = list;
@@ -293,11 +296,12 @@ function showChatBubble(id, text) {
       const idx = activeBubbles.findIndex((b) => b.sprite === old);
       if (idx >= 0) activeBubbles.splice(idx, 1);
     }
-    list.forEach((b, i) => b.position.set(0, 2.6 + i * 0.35, 0));
+    list.forEach((b, i) => b.position.set(0, BUBBLE_BASE + i * BUBBLE_SPACING, 0));
   }
 
   if (root.userData.typingBubble) {
-    root.userData.typingBubble.position.y = 2.6 + list.length * 0.35;
+    root.userData.typingBubble.position.y =
+      BUBBLE_BASE + list.length * BUBBLE_SPACING;
   }
 
   activeBubbles.push({ sprite: bubble, root, ttl: 4.5 });
@@ -310,7 +314,14 @@ function showTyping(id, flag) {
     if (root.userData.typingBubble) return;
     const bubble = makeChatBubble('...');
     bubble.scale.multiplyScalar(0.6);
-    bubble.position.set(0, 2.6 + (root.userData.chatBubbles ? root.userData.chatBubbles.length * 0.35 : 0), 0);
+    bubble.position.set(
+      0,
+      BUBBLE_BASE +
+        (root.userData.chatBubbles
+          ? root.userData.chatBubbles.length * BUBBLE_SPACING
+          : 0),
+      0
+    );
     root.add(bubble);
     root.userData.typingBubble = bubble;
   } else {
@@ -738,11 +749,9 @@ socket.on('connect', () => {
 
   initLoginGate({
     onGuest() {
-      document.getElementById('loginGate').style.display = 'none';
       showCharCreator();
     },
     onGoogle(idToken) {
-      document.getElementById('loginGate').style.display = 'none';
       showCharCreator(idToken);
     },
   });
@@ -750,6 +759,9 @@ socket.on('connect', () => {
 
 // Character creator entry point ------------------------------------------
 function showCharCreator(idToken = null) {
+  // Guests don't see the friends tab
+  friendsBtn.style.display = idToken ? '' : 'none';
+  friendsPanel.style.display = idToken ? '' : 'none';
   overlay.classList.remove('hidden');
   initPreview();
   updatePreviewColor(palette[selectedIdx]);


### PR DESCRIPTION
## Summary
- Hide welcome gate when playing as guest so character preview works
- Spread out and resize chat bubbles with dynamic widths
- Move history/friends buttons to a bottom bar and hide friends for guests

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c744b343083278221ece911cb670a