### PR TITLE
Improve chat bubbles and add bottom bar logout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -115,8 +115,9 @@ button.guest{background:#10b981;border:0;color:#fff;font-weight:600;
   padding:10px 14px;font-weight:600;cursor:pointer}
 
 /* bottom utility bar */
-#bottomBar{position:fixed;right:12px;bottom:12px;display:flex;gap:8px;z-index:11}
+#bottomBar{position:fixed;left:0;right:0;bottom:0;display:flex;justify-content:flex-end;gap:8px;z-index:11;padding:8px 12px;background:rgba(9,13,24,.7);border-top:1px solid #1f2a44;backdrop-filter:blur(6px)}
 #bottomBar button{background:#334155;color:#e2e8f0;border:0;border-radius:8px;padding:8px 12px;cursor:pointer}
+#logoutBtn{display:none;background:#dc2626;color:#fff}
 
 /* side panels */
 .sidePanel{position:fixed;top:0;right:0;width:260px;height:100%;
@@ -178,6 +179,7 @@ button.guest{background:#10b981;border:0;color:#fff;font-weight:600;
 <div id="bottomBar">
   <button id="historyBtn">History</button>
   <button id="friendsBtn">Friends</button>
+  <button id="logoutBtn">Logout</button>
 </div>
 
 <!-- side panels -->


### PR DESCRIPTION
## Summary
- Dynamically size and stack chat bubbles based on message content
- Add persistent bottom bar with history, friends, and logout controls
- Replace downloaded background audio with generated cave ambience

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c775a67788327b021ff8676df2da1