### PR TITLE
Fix chat bubble stacking, dismiss login gate reliably, remove glare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@ body{overflow:hidden;background:#0b0e16}
 <!-- ============ Waiting-Room backdrop ============ -->
 <style>
 /* vignette + oven glow (behind everything visual but above page bg) */
-body::before,body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:0}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:0}
 
 /* edge darkening */
 body::before{
@@ -26,16 +26,7 @@ body::before{
               transparent 0%,rgba(0,0,0,.55) 100%);
 }
 
-/* subtle orange “oven” glow */
-body::after{
-  background:radial-gradient(560px 360px at 6% 92%,
-              rgba(255,110,40,.22) 0%,
-              rgba(255,110,40,.06) 45%,
-              transparent 100%);
-  mix-blend-mode:screen;
-  animation:glowPulse 8s ease-in-out infinite alternate;
-}
-@keyframes glowPulse{to{transform:scale(1.05);opacity:.85}}
+/* subtle orange “oven” glow removed */
 
 /* ------ floating dust motes ------ */
 .dustWrap{position:fixed;inset:0;overflow:hidden;pointer-events:none;z-index:1}

--- a/public/login.js
+++ b/public/login.js
@@ -3,9 +3,11 @@ export function initLoginGate({ onGuest, onGoogle }) {
   const loginGate = document.getElementById('loginGate');
   const guestBtn  = document.getElementById('guestBtn');
   const loginMsg  = document.getElementById('loginMsg');
+  let gateDismissed = false;
 
   guestBtn.onclick = () => {
     // Hide the welcome gate when playing as guest
+    gateDismissed = true;
     loginGate.style.display = 'none';
     onGuest();
   };
@@ -17,6 +19,7 @@ export function initLoginGate({ onGuest, onGoogle }) {
     auto_select : true,          // <── keeps them signed-in
     callback  : (resp) => {
       console.log('got token', resp.credential);
+      gateDismissed = true;
       loginGate.style.display = 'none';        // hide gate instantly
       onGoogle(resp.credential);
     }
@@ -24,13 +27,17 @@ export function initLoginGate({ onGuest, onGoogle }) {
 
   // Ask GIS whether it can auto-sign-in.  If not, we’ll render buttons below.
   google.accounts.id.prompt((notification) => {
-    if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+    if (
+      !gateDismissed &&
+      (notification.isNotDisplayed() || notification.isSkippedMoment())
+    ) {
       // Auto-sign-in failed ➜ show the gate with our buttons
       renderButtons();
     }
   });
 
   function renderButtons() {
+    if (gateDismissed) return;
     loginGate.style.display = 'flex';          // gate is hidden by default
     google.accounts.id.renderButton(
       document.getElementById('gSignIn'),

--- a/public/main.js
+++ b/public/main.js
@@ -325,11 +325,13 @@ function showChatBubble(id, text) {
   const list = root.userData.chatBubbles || [];
   const bubble = makeChatBubble(text);
   root.add(bubble);
-  list.push(bubble);
+  // Insert newest bubble at start so older ones are pushed upward
+  list.unshift(bubble);
   root.userData.chatBubbles = list;
 
+  // Limit to 3 bubbles, removing the oldest (last in the array)
   if (list.length > 3) {
-    const old = list.shift();
+    const old = list.pop();
     if (old) {
       root.remove(old);
       const idx = activeBubbles.findIndex((b) => b.sprite === old);


### PR DESCRIPTION
## Summary
- Show newest chat bubbles at the bottom and push older ones upward
- Ensure guest play hides the start menu permanently until next load
- Remove orange glare overlay from page background

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_689c79077b1883279c46607ad1822cec